### PR TITLE
Add redis-url and redis-insecure-tls command line options

### DIFF
--- a/redis_info_handlers.go
+++ b/redis_info_handlers.go
@@ -30,7 +30,7 @@ func newRedisInfoHandlerFunc(rdb *redis.Client) http.HandlerFunc {
 		}
 		info := parseRedisInfo(res)
 		resp := RedisInfoResponse{
-			Addr:    flagRedisAddr,
+			Addr:    rdb.Options().Addr,
 			Info:    info,
 			RawInfo: res,
 		}


### PR DESCRIPTION
A URL can contain all of the information in the individual flags as a
single string rather than as separate pieces. I've mostly run into URLs
pointing to Redis and this make those existing URLs easier to work with.

This also introduces the -redis-insecure-tls flag which turns off TLS
certificate hostname verification. We've chosen Heroku Redis for a
recent project which requires TLS but, for reasons I don't know, they
don't provide a certificate that is valid for the hostname. I also
wasn't able to get the existing -redis-tls flag to work.

I've left the original flags for backwards compatibility but I also feel they're clunky and should be removed. The new flags use dashes (-) instead of underscores (_) since that's what I'm more use to with other commands in the Linux space. Didn't realize it until I was reviewing it for the PR but happy to change them.

On another note, thanks for Asynq. I spent a long time looking at alternative background job systems in Go and compared to everything else it's really well done and thought out. 🎉 