### PR TITLE
support redis sentinel config#added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ docker:
 	docker run --rm \
 		--name asynqmon \
 		-p 8080:8080 \
-		asynqmon --redis-addr=host.docker.internal:6379
+		asynqmon --redis-addrs=host.docker.internal:6379

--- a/README.md
+++ b/README.md
@@ -96,16 +96,18 @@ docker run hibiken/asynqmon --help
 
 Here's the available flags:
 
-_Note_: Use `--redis-url` to specify address, db-number, and password with one flag value; Alternatively, use `--redis-addr`, `--redis-db`, and `--redis-password` to specify each value.
+_Note_: Use `--redis-url` to specify address, db-number, and password with one flag value; Alternatively, use `--redis-addrs`, `--redis-db`, and `--redis-password` to specify each value.
 
 | Flag                              | Env                       | Description                                                         | Default          |
 | --------------------------------- | ------------------------- | ------------------------------------------------------------------- | ---------------- |
 | `--port`(int)                     | `PORT`                    | port number to use for web ui server                                | 8080             |
-| `---redis-url`(string)            | `REDIS_URL`               | URL to redis server                                                 | ""               |
-| `--redis-addr`(string)            | `REDIS_ADDR`              | address of redis server to connect to                               | "127.0.0.1:6379" |
+| `--redis-url`(string)           m | `REDIS_URL`                | URL to redis server                                                 | ""               |
+| `--redis-addr`(string)(Deprecated)| `REDIS_ADDR`              | address of redis server to connect to                               | "127.0.0.1:6379" |
+| `--redis-addrs`(string)           | `REDIS_ADDRS`             | comma separated list of host:port addresses                         | "127.0.0.1:6379" |
+| `--redis-master-name`(string)     | `REDIS_MASTER_NAME`       | redis master name for redis sentinel                  			  | ""               |
 | `--redis-db`(int)                 | `REDIS_DB`                | redis database number                                               | 0                |
 | `--redis-password`(string)        | `REDIS_PASSWORD`          | password to use when connecting to redis server                     | ""               |
-| `--redis-cluster-nodes`(string)   | `REDIS_CLUSTER_NODES`     | comma separated list of host:port addresses of cluster nodes        | ""               |
+| `--redis-cluster-nodes`(string)(Deprecated)  | `REDIS_CLUSTER_NODES`     | comma separated list of host:port addresses of cluster nodes        | ""               |
 | `--redis-tls`(string)             | `REDIS_TLS`               | server name for TLS validation used when connecting to redis server | ""               |
 | `--redis-insecure-tls`(bool)      | `REDIS_INSECURE_TLS`      | disable TLS certificate host checks                                 | false            |
 | `--enable-metrics-exporter`(bool) | `ENABLE_METRICS_EXPORTER` | enable prometheus metrics exporter to expose queue metrics          | false            |
@@ -128,7 +130,10 @@ The address can be specified via `--prometheus-addr`. This enables the metrics v
 
 ```bash
 # with a local binary; custom port and connect to redis server at localhost:6380
-./asynqmon --port=3000 --redis-addr=localhost:6380
+./asynqmon --port=3000 --redis-addrs=localhost:6380
+
+# for redis sentinel local binary
+./asynqmon --port=3000 --redis-addrs=localhost:26379 --redis-master-name=mymaster
 
 # with prometheus integration enabled
 ./asynqmon --enable-metrics-exporter --prometheus-addr=http://localhost:9090
@@ -137,14 +142,14 @@ The address can be specified via `--prometheus-addr`. This enables the metrics v
 docker run --rm \
     --name asynqmon \
     -p 3000:3000 \
-    hibiken/asynqmon --port=3000 --redis-addr=host.docker.internal:6380
+    hibiken/asynqmon --port=3000 --redis-addrs=host.docker.internal:6380
 
 # with Docker (connect to a Redis server running in the Docker container)
 docker run --rm \
     --name asynqmon \
     --network dev-network \
     -p 8080:8080 \
-    hibiken/asynqmon --redis-addr=dev-redis:6379
+    hibiken/asynqmon --redis-addrs=dev-redis:6379
 ```
 
 Next, go to [localhost:8080](http://localhost:8080) and see Asynqmon dashboard:

--- a/cmd/asynqmon/main.go
+++ b/cmd/asynqmon/main.go
@@ -23,29 +23,32 @@ import (
 // Command-line flags
 var (
 	flagPort                  int
-	flagRedisAddr             string
+	flagRedisAddrs            string
 	flagRedisDB               int
 	flagRedisPassword         string
 	flagRedisTLS              string
 	flagRedisURL              string
 	flagRedisInsecureTLS      bool
-	flagRedisClusterNodes     string
+	flagRedisSentinels        string
 	flagMaxPayloadLength      int
 	flagMaxResultLength       int
 	flagEnableMetricsExporter bool
 	flagPrometheusServerAddr  string
 	flagReadOnly              bool
+	flagMasterName            string
 )
 
 func init() {
 	flag.IntVar(&flagPort, "port", getEnvOrDefaultInt("PORT", 8080), "port number to use for web ui server")
-	flag.StringVar(&flagRedisAddr, "redis-addr", getEnvDefaultString("REDIS_ADDR", "127.0.0.1:6379"), "address of redis server to connect to")
+	flag.StringVar(&flagRedisAddrs, "redis-addrs", getEnvDefaultString("REDIS_ADDRS", "127.0.0.1:6379"), "comma separated list of host:port addresses")
 	flag.IntVar(&flagRedisDB, "redis-db", getEnvOrDefaultInt("REDIS_DB", 0), "redis database number")
+	flag.StringVar(&flagMasterName, "redis-master-name", getEnvDefaultString("REDIS_MASTER_NAME", ""), "redis master name for redis sentinel")
 	flag.StringVar(&flagRedisPassword, "redis-password", getEnvDefaultString("REDIS_PASSWORD", ""), "password to use when connecting to redis server")
 	flag.StringVar(&flagRedisTLS, "redis-tls", getEnvDefaultString("REDIS_TLS", ""), "server name for TLS validation used when connecting to redis server")
 	flag.StringVar(&flagRedisURL, "redis-url", getEnvDefaultString("REDIS_URL", ""), "URL to redis server")
 	flag.BoolVar(&flagRedisInsecureTLS, "redis-insecure-tls", getEnvOrDefaultBool("REDIS_INSECURE_TLS", false), "disable TLS certificate host checks")
-	flag.StringVar(&flagRedisClusterNodes, "redis-cluster-nodes", getEnvDefaultString("REDIS_CLUSTER_NODES", ""), "comma separated list of host:port addresses of cluster nodes")
+	flag.StringVar(&flagRedisSentinels, "redis-sentinels", getEnvDefaultString("REDIS_SENTINELS", ""), "comma separated list of host:port addresses of cluster nodes")
+
 	flag.IntVar(&flagMaxPayloadLength, "max-payload-length", getEnvOrDefaultInt("MAX_PAYLOAD_LENGTH", 200), "maximum number of utf8 characters printed in the payload cell in the Web UI")
 	flag.IntVar(&flagMaxResultLength, "max-result-length", getEnvOrDefaultInt("MAX_RESULT_LENGTH", 200), "maximum number of utf8 characters printed in the result cell in the Web UI")
 	flag.BoolVar(&flagEnableMetricsExporter, "enable-metrics-exporter", getEnvOrDefaultBool("ENABLE_METRICS_EXPORTER", false), "enable prometheus metrics exporter to expose queue metrics")
@@ -57,9 +60,8 @@ func init() {
 // IDEA: https://eli.thegreenplace.net/2020/testing-flag-parsing-in-go-programs/
 func getRedisOptionsFromFlags() (asynq.RedisConnOpt, error) {
 	var opts redis.UniversalOptions
-
-	if flagRedisClusterNodes != "" {
-		opts.Addrs = strings.Split(flagRedisClusterNodes, ",")
+	if flagRedisAddrs != "" {
+		opts.Addrs = strings.Split(flagRedisAddrs, ",")
 		opts.Password = flagRedisPassword
 	} else {
 		if flagRedisURL != "" {
@@ -70,11 +72,6 @@ func getRedisOptionsFromFlags() (asynq.RedisConnOpt, error) {
 			opts.Addrs = append(opts.Addrs, res.Addr)
 			opts.DB = res.DB
 			opts.Password = res.Password
-
-		} else {
-			opts.Addrs = []string{flagRedisAddr}
-			opts.DB = flagRedisDB
-			opts.Password = flagRedisPassword
 		}
 	}
 
@@ -87,8 +84,15 @@ func getRedisOptionsFromFlags() (asynq.RedisConnOpt, error) {
 		}
 		opts.TLSConfig.InsecureSkipVerify = true
 	}
-
-	if flagRedisClusterNodes != "" {
+	if flagMasterName != "" {
+		return asynq.RedisFailoverClientOpt{
+			SentinelAddrs: opts.Addrs,
+			MasterName:    flagMasterName,
+			Password:      opts.Password,
+			TLSConfig:     opts.TLSConfig,
+		}, nil
+	}
+	if len(flagRedisAddrs) > 1 {
 		return asynq.RedisClusterClientOpt{
 			Addrs:     opts.Addrs,
 			Password:  opts.Password,


### PR DESCRIPTION
**Background**
Currently, Redis v8 doesn't support passing Redis sentinels via URL as I know from their code.
```
func ParseURL(redisURL string) (*Options, error) {
	u, err := url.Parse(redisURL)
	if err != nil {
		return nil, err
	}

	switch u.Scheme {
	case "redis", "rediss":
		return setupTCPConn(u)
	case "unix":
		return setupUnixConn(u)
	default:
		return nil, fmt.Errorf("redis: invalid URL scheme: %s", u.Scheme)
	}
}
```
So, As the author @hibiken  mentioned in https://github.com/hibiken/asynqmon/issues/235 will not perform for Redis sentinels, terminal will show an error as Redis v8 defined `redis: invalid URL scheme redis+sentinel`


**Why did we need it?**
- Support pass Redis sentinel config via passing `redis-master-name` and `redis-addrs` to flag or `REDIS_MASTER_NAME` and `REDIS_ADDS` to environment
- Refactor flag that we will flag `redis-addrs` to detect users who want to use Redis standalone or clusters when do not pass `redis-master-name`, otherwise it will be redis sentinels. So we can deprecate `redis-addr` and `redis-cluster-nodes` flag 





#fixed https://github.com/hibiken/asynqmon/issues/235