### PR TITLE
Add MIME type to served files

### DIFF
--- a/static.go
+++ b/static.go
@@ -98,6 +98,14 @@ func (h *uiAssetsHandler) serveFile(w http.ResponseWriter, path string) (code in
 		}
 		return http.StatusInternalServerError, err
 	}
+	// Setting the MIME type for .js files manually to application/javascript as
+	// http.DetectContentType is using https://mimesniff.spec.whatwg.org/ which
+	// will not recognize application/javascript for security reasons.
+	if strings.HasSuffix(path, ".js") {
+		w.Header().Add("Content-Type", "application/javascript")
+	} else {
+		w.Header().Add("Content-Type", http.DetectContentType(bytes))
+	}
 
 	if _, err := w.Write(bytes); err != nil {
 		return http.StatusInternalServerError, err

--- a/static.go
+++ b/static.go
@@ -102,7 +102,7 @@ func (h *uiAssetsHandler) serveFile(w http.ResponseWriter, path string) (code in
 	// http.DetectContentType is using https://mimesniff.spec.whatwg.org/ which
 	// will not recognize application/javascript for security reasons.
 	if strings.HasSuffix(path, ".js") {
-		w.Header().Add("Content-Type", "application/javascript")
+		w.Header().Add("Content-Type", "application/javascript; charset=utf-8")
 	} else {
 		w.Header().Add("Content-Type", http.DetectContentType(bytes))
 	}


### PR DESCRIPTION
Currently, all JS files are served as "content-type: text/plain; charset=utf-8"  which is a problem if MIME sniffing is disabled for the domain that Asynqmon is hosted on.

This PR sets the Content-Type header manually for files ending in .js and tries to detect the MIME type for other files.