### PR TITLE
Added heading for packages + added Fiber example

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Next, go to [localhost:8080](http://localhost:8080) and see Asynqmon dashboard:
 
 Asynqmon is also a library which can be imported into an existing web application.
 
-Example with [net/http](https://pkg.go.dev/net/http):
+### [net/http](https://pkg.go.dev/net/http)
 
 ```go
 package main
@@ -212,7 +212,7 @@ func main() {
 		RedisConnOpt: asynq.RedisClientOpt{Addr: ":6379"},
 	})
 
-    // Note: We need the tailing slash when using net/http.ServeMux.
+	// Note: We need the tailing slash when using net/http.ServeMux.
 	http.Handle(h.RootPath()+"/", h)
 
 	// Go to http://localhost:8080/monitoring to see asynqmon homepage.
@@ -220,7 +220,7 @@ func main() {
 }
 ```
 
-Example with [gorilla/mux](https://pkg.go.dev/github.com/gorilla/mux):
+### [gorilla/mux](https://pkg.go.dev/github.com/gorilla/mux)
 
 ```go
 package main
@@ -253,8 +253,7 @@ func main() {
 }
 ```
 
-Example with [labstack/echo](https://github.com/labstack/echo)):
-
+### [labstack/echo](https://github.com/labstack/echo)
 
 ```go
 package main
@@ -280,7 +279,6 @@ func main() {
 	e.Start(":8080")
 }
 ```
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,36 @@ func main() {
 }
 ```
 
+### [gofiber/fiber](https://github.com/gofiber/fiber)
+
+```go
+package main
+
+import (
+	"log"
+
+	"github.com/gofiber/adaptor/v2"
+	"github.com/gofiber/fiber/v2"
+	"github.com/hibiken/asynq"
+	"github.com/hibiken/asynqmon"
+)
+
+func main() {
+	app := fiber.New(fiber.Config{})
+
+	app.All("/monitoring/tasks/*", adaptor.HTTPHandler(asynqmon.New(asynqmon.Options{
+		RootPath: "/monitoring/tasks",
+		RedisConnOpt: asynq.RedisClientOpt{
+			Addr:     ":6379",
+			Password: "",
+			DB:       0,
+		},
+	})))
+
+	log.Fatal(app.Listen(":8080"))
+}
+```
+
 ## License
 
 Copyright (c) 2019-present [Ken Hibino](https://github.com/hibiken) and [Contributors](https://github.com/hibiken/asynqmon/graphs/contributors). `Asynqmon` is free and open-source software licensed under the [MIT License](https://github.com/hibiken/asynq/blob/master/LICENSE). Official logo was created by [Vic Shóstak](https://github.com/koddr) and distributed under [Creative Commons](https://creativecommons.org/publicdomain/zero/1.0/) license (CC0 1.0 Universal).


### PR DESCRIPTION
I've changed the example text to be actual headings, which should improve readability. I've also resolved some incorrect spacing and added an example for Fiber.