### PR TITLE
add an example middleware to implement basic auth into asynqmon handler

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -17,3 +17,36 @@ func ExampleHTTPHandler() {
 	http.Handle(h.RootPath(), h)
 	log.Fatal(http.ListenAndServe(":8000", nil)) // visit localhost:8000/monitoring to see asynqmon homepage
 }
+
+func ExampleHTTPHandlerWithBasicAuthMidlleware() {
+
+	h := asynqmon.New(asynqmon.Options{
+		RootPath:     "/monitoring",
+		RedisConnOpt: asynq.RedisClientOpt{Addr: ":6379"},
+	})
+
+	http.Handle(h.RootPath(), basicAuthHandler("username", "password", h))
+	log.Fatal(http.ListenAndServe(":8000", nil)) // visit localhost:8000/monitoring to see asynqmon homepage
+}
+
+func basicAuthHandler(u, p string, next http.Handler) http.Handler {
+	var unauthorized = func(w http.ResponseWriter) {
+		w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			unauthorized(w)
+			return
+		}
+
+		if !(u == username && p == password) {
+			unauthorized(w)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -31,7 +31,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
Hi @hibiken, I just find out that there is no RBAC in asynqmon web. So I just try to give some example to prevent unauthenticated user to access by implementing basic auth

To use basic auth, It needs some changes in the UI, so put the attribute crossorigin=use-credentials so the manifest.json files can be loaded (in Chrome)

![Screen Shot 2022-12-29 at 02 15 11](https://user-images.githubusercontent.com/28580023/209861588-09dc557f-0170-4b99-8cdd-c3179d863f52.png)

Looking forward for the review
Thanks 😊