### PR TITLE
add root_path to flag and env options

### DIFF
--- a/cmd/asynqmon/main.go
+++ b/cmd/asynqmon/main.go
@@ -25,6 +25,9 @@ type Config struct {
 	// Server port
 	Port int
 
+	// Server path url
+	RootPath string
+
 	// Redis connection options
 	RedisAddr         string
 	RedisDB           int
@@ -72,6 +75,7 @@ func parseFlags(progname string, args []string) (cfg *Config, output string, err
 	flags.BoolVar(&conf.EnableMetricsExporter, "enable-metrics-exporter", getEnvOrDefaultBool("ENABLE_METRICS_EXPORTER", false), "enable prometheus metrics exporter to expose queue metrics")
 	flags.StringVar(&conf.PrometheusServerAddr, "prometheus-addr", getEnvDefaultString("PROMETHEUS_ADDR", ""), "address of prometheus server to query time series")
 	flags.BoolVar(&conf.ReadOnly, "read-only", getEnvOrDefaultBool("READ_ONLY", false), "restrict to read-only mode")
+	flags.StringVar(&conf.RootPath, "root-path", getEnvDefaultString("ROOT_PATH", "/"), "root path prefix for url")
 
 	err = flags.Parse(args)
 	if err != nil {
@@ -153,6 +157,7 @@ func main() {
 		ResultFormatter:   asynqmon.ResultFormatterFunc(resultFormatterFunc(cfg)),
 		PrometheusAddress: cfg.PrometheusServerAddr,
 		ReadOnly:          cfg.ReadOnly,
+		RootPath:          cfg.RootPath,
 	})
 	defer h.Close()
 


### PR DESCRIPTION
Hello, I would like to deploy Asynqmon to my domain which can be accessed from domain + prefix path. Ex: `https://mydomain.com/asynq` 

I see the options have `RootPath` config already but I need pass this config by using ENV or arguments.
So, please review my MR for this feature! Thank you.