### PR TITLE
Allow to provide username when configuring Redis connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,13 @@ Here's the available flags:
 _Note_: Use `--redis-url` to specify address, db-number, and password with one flag value; Alternatively, use `--redis-addr`, `--redis-db`, and `--redis-password` to specify each value.
 
 | Flag                              | Env                       | Description                                                                                                                  | Default          |
-| --------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+|-----------------------------------|---------------------------|------------------------------------------------------------------------------------------------------------------------------| ---------------- |
 | `--port`(int)                     | `PORT`                    | port number to use for web ui server                                                                                         | 8080             |
 | `---redis-url`(string)            | `REDIS_URL`               | URL to redis or sentinel server. See [godoc](https://pkg.go.dev/github.com/hibiken/asynq#ParseRedisURI) for supported format | ""               |
 | `--redis-addr`(string)            | `REDIS_ADDR`              | address of redis server to connect to                                                                                        | "127.0.0.1:6379" |
 | `--redis-db`(int)                 | `REDIS_DB`                | redis database number                                                                                                        | 0                |
 | `--redis-password`(string)        | `REDIS_PASSWORD`          | password to use when connecting to redis server                                                                              | ""               |
+| `--redis-username`(string)        | `REDIS_USERNAME`          | user name to use when connecting to redis server                                                                             | ""               |
 | `--redis-cluster-nodes`(string)   | `REDIS_CLUSTER_NODES`     | comma separated list of host:port addresses of cluster nodes                                                                 | ""               |
 | `--redis-tls`(string)             | `REDIS_TLS`               | server name for TLS validation used when connecting to redis server                                                          | ""               |
 | `--redis-insecure-tls`(bool)      | `REDIS_INSECURE_TLS`      | disable TLS certificate host checks                                                                                          | false            |

--- a/cmd/asynqmon/main.go
+++ b/cmd/asynqmon/main.go
@@ -29,6 +29,7 @@ type Config struct {
 	RedisAddr         string
 	RedisDB           int
 	RedisPassword     string
+	RedisUsername     string
 	RedisTLS          string
 	RedisURL          string
 	RedisInsecureTLS  bool
@@ -63,6 +64,7 @@ func parseFlags(progname string, args []string) (cfg *Config, output string, err
 	flags.StringVar(&conf.RedisAddr, "redis-addr", getEnvDefaultString("REDIS_ADDR", "127.0.0.1:6379"), "address of redis server to connect to")
 	flags.IntVar(&conf.RedisDB, "redis-db", getEnvOrDefaultInt("REDIS_DB", 0), "redis database number")
 	flags.StringVar(&conf.RedisPassword, "redis-password", getEnvDefaultString("REDIS_PASSWORD", ""), "password to use when connecting to redis server")
+	flags.StringVar(&conf.RedisUsername, "redis-username", getEnvDefaultString("REDIS_USERNAME", ""), "user name to use when connecting to redis server")
 	flags.StringVar(&conf.RedisTLS, "redis-tls", getEnvDefaultString("REDIS_TLS", ""), "server name for TLS validation used when connecting to redis server")
 	flags.StringVar(&conf.RedisURL, "redis-url", getEnvDefaultString("REDIS_URL", ""), "URL to redis server")
 	flags.BoolVar(&conf.RedisInsecureTLS, "redis-insecure-tls", getEnvOrDefaultBool("REDIS_INSECURE_TLS", false), "disable TLS certificate host checks")
@@ -96,6 +98,7 @@ func makeRedisConnOpt(cfg *Config) (asynq.RedisConnOpt, error) {
 	if len(cfg.RedisClusterNodes) > 0 {
 		return asynq.RedisClusterClientOpt{
 			Addrs:     strings.Split(cfg.RedisClusterNodes, ","),
+			Username:  cfg.RedisUsername,
 			Password:  cfg.RedisPassword,
 			TLSConfig: makeTLSConfig(cfg),
 		}, nil
@@ -123,6 +126,7 @@ func makeRedisConnOpt(cfg *Config) (asynq.RedisConnOpt, error) {
 	} else {
 		connOpt.Addr = cfg.RedisAddr
 		connOpt.DB = cfg.RedisDB
+		connOpt.Username = cfg.RedisUsername
 		connOpt.Password = cfg.RedisPassword
 	}
 	if connOpt.TLSConfig == nil {


### PR DESCRIPTION
I am setting up Asynqmon with AWS MemoryDB service that uses username. This PR adds support for `username` when connecting to Redis.