### PR TITLE
support username in redis cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ _Note_: Use `--redis-url` to specify address, db-number, and password with one f
 | `---redis-url`(string)            | `REDIS_URL`               | URL to redis or sentinel server. See [godoc](https://pkg.go.dev/github.com/hibiken/asynq#ParseRedisURI) for supported format | ""               |
 | `--redis-addr`(string)            | `REDIS_ADDR`              | address of redis server to connect to                                                                                        | "127.0.0.1:6379" |
 | `--redis-db`(int)                 | `REDIS_DB`                | redis database number                                                                                                        | 0                |
+| `--redis-username`(string)        | `REDIS_USERNAME`          | username to use when connecting to redis server                                                                              | ""               |
 | `--redis-password`(string)        | `REDIS_PASSWORD`          | password to use when connecting to redis server                                                                              | ""               |
 | `--redis-cluster-nodes`(string)   | `REDIS_CLUSTER_NODES`     | comma separated list of host:port addresses of cluster nodes                                                                 | ""               |
 | `--redis-tls`(string)             | `REDIS_TLS`               | server name for TLS validation used when connecting to redis server                                                          | ""               |

--- a/cmd/asynqmon/main.go
+++ b/cmd/asynqmon/main.go
@@ -28,6 +28,7 @@ type Config struct {
 	// Redis connection options
 	RedisAddr         string
 	RedisDB           int
+	RedisUsername     string
 	RedisPassword     string
 	RedisTLS          string
 	RedisURL          string
@@ -62,6 +63,7 @@ func parseFlags(progname string, args []string) (cfg *Config, output string, err
 	flags.IntVar(&conf.Port, "port", getEnvOrDefaultInt("PORT", 8080), "port number to use for web ui server")
 	flags.StringVar(&conf.RedisAddr, "redis-addr", getEnvDefaultString("REDIS_ADDR", "127.0.0.1:6379"), "address of redis server to connect to")
 	flags.IntVar(&conf.RedisDB, "redis-db", getEnvOrDefaultInt("REDIS_DB", 0), "redis database number")
+	flags.StringVar(&conf.RedisUsername, "redis-username", getEnvDefaultString("REDIS_USER", ""), "username to use when connecting to redis server")
 	flags.StringVar(&conf.RedisPassword, "redis-password", getEnvDefaultString("REDIS_PASSWORD", ""), "password to use when connecting to redis server")
 	flags.StringVar(&conf.RedisTLS, "redis-tls", getEnvDefaultString("REDIS_TLS", ""), "server name for TLS validation used when connecting to redis server")
 	flags.StringVar(&conf.RedisURL, "redis-url", getEnvDefaultString("REDIS_URL", ""), "URL to redis server")
@@ -96,6 +98,7 @@ func makeRedisConnOpt(cfg *Config) (asynq.RedisConnOpt, error) {
 	if len(cfg.RedisClusterNodes) > 0 {
 		return asynq.RedisClusterClientOpt{
 			Addrs:     strings.Split(cfg.RedisClusterNodes, ","),
+			Username:  cfg.RedisUsername,
 			Password:  cfg.RedisPassword,
 			TLSConfig: makeTLSConfig(cfg),
 		}, nil
@@ -123,6 +126,7 @@ func makeRedisConnOpt(cfg *Config) (asynq.RedisConnOpt, error) {
 	} else {
 		connOpt.Addr = cfg.RedisAddr
 		connOpt.DB = cfg.RedisDB
+		connOpt.Username = cfg.RedisUsername
 		connOpt.Password = cfg.RedisPassword
 	}
 	if connOpt.TLSConfig == nil {


### PR DESCRIPTION
Adds support for specifying the username when connecting to Redis. Still doesn't support redis username in the full url however